### PR TITLE
Save properties of a test case

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -64,10 +64,11 @@ func ingestProperties(root xmlNode) map[string]string {
 
 func ingestTestcase(root xmlNode) Test {
 	test := Test{
-		Name:      root.Attr("name"),
-		Classname: root.Attr("classname"),
-		Duration:  duration(root.Attr("time")),
-		Status:    StatusPassed,
+		Name:       root.Attr("name"),
+		Classname:  root.Attr("classname"),
+		Duration:   duration(root.Attr("time")),
+		Status:     StatusPassed,
+		Properties: root.Attrs,
 	}
 
 	for _, node := range root.Nodes {

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -1,0 +1,74 @@
+// Copyright Josh Komoroske. All rights reserved.
+// Use of this source code is governed by the MIT license,
+// a copy of which can be found in the LICENSE.txt file.
+
+package junit
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestInjest(t *testing.T) {
+	tests := []struct {
+		title    string
+		input    []byte
+		expected string
+	}{
+		{
+			title: "xml input",
+			input: []byte(`<testsuite errors="0" failures="1" file="Foo.java"><testcase name="unit tests" file="Foo.java"/></testsuite>`),
+			expected: `
+[
+  {
+    "name": "",
+    "package": "",
+    "tests": [
+      {
+        "name": "unit tests",
+        "classname": "",
+        "duration": 0,
+        "status": "passed",
+        "error": null,
+        "Properties": {
+          "file": "Foo.java",
+          "name": "unit tests"
+        }
+      }
+    ],
+    "totals": {
+      "tests": 1,
+      "passed": 1,
+      "skipped": 0,
+      "failed": 0,
+      "error": 0,
+      "duration": 0
+    }
+  }
+]`,
+		},
+	}
+
+	for index, test := range tests {
+		name := fmt.Sprintf("#%d - %s", index+1, test.title)
+
+		t.Run(name, func(t *testing.T) {
+			actual, err := Ingest(test.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if actual == nil {
+				t.Fatalf("No suites found!")
+			}
+
+			actualJSON, err := json.MarshalIndent(actual, "", "  ")
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, strings.TrimSpace(test.expected), string(actualJSON))
+		})
+	}
+}

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -7,9 +7,10 @@ package junit
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInjest(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -130,7 +130,7 @@ type Test struct {
 
 	// Additional properties from XML node attributes.
 	// Some tools use them to store additional information about test location.
-	Properties map[string]string
+	Properties map[string]string `json:"properties" yaml:"properties"`
 }
 
 // Error represents an erroneous test result.

--- a/types.go
+++ b/types.go
@@ -127,6 +127,10 @@ type Test struct {
 	//   Error == nil && (Status == Passed || Status == Skipped)
 	//   Error != nil && (Status == Failed || Status == Error)
 	Error error `json:"error" yaml:"error"`
+
+	// Additional properties from XML node attributes.
+	// Some tools use them to store additional information about test location.
+	Properties map[string]string
 }
 
 // Error represents an erroneous test result.


### PR DESCRIPTION
Some reporters use them to store additional information like file location