### PR TITLE
Add support for reading stdout/stderr for each test case

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -80,6 +80,10 @@ func ingestTestcase(root xmlNode) Test {
 		case "error":
 			test.Error = ingestError(node)
 			test.Status = StatusError
+		case "system-out":
+			test.SystemOut = string(node.Content)
+		case "system-err":
+			test.SystemErr = string(node.Content)
 		}
 	}
 

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInjest(t *testing.T) {
+func TestIngest(t *testing.T) {
 	tests := []struct {
 		title    string
 		input    []byte
@@ -19,7 +19,7 @@ func TestInjest(t *testing.T) {
 	}{
 		{
 			title: "xml input",
-			input: []byte(`<testsuite errors="0" failures="1" file="Foo.java"><testcase name="unit tests" file="Foo.java"/></testsuite>`),
+			input: []byte(`<testsuite errors="0" failures="1" file="Foo.java"><testcase name="unit tests" file="Foo.java"><system-out><![CDATA[Hello, World]]></system-out></testcase></testsuite>`),
 			expected: []Suite{
 				{
 					Tests: []Test{
@@ -30,6 +30,7 @@ func TestInjest(t *testing.T) {
 								"file": "Foo.java",
 								"name": "unit tests",
 							},
+							SystemOut: "Hello, World",
 						},
 					},
 					Totals: Totals{

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -19,7 +19,12 @@ func TestIngest(t *testing.T) {
 	}{
 		{
 			title: "xml input",
-			input: []byte(`<testsuite errors="0" failures="1" file="Foo.java"><testcase name="unit tests" file="Foo.java"><system-out><![CDATA[Hello, World]]></system-out></testcase></testsuite>`),
+			input: []byte(`<testsuite errors="0" failures="1" file="Foo.java">
+				<testcase name="unit tests" file="Foo.java">
+					<system-out><![CDATA[Hello, World]]></system-out>
+					<system-err><![CDATA[I'm an error!]]></system-err>
+				</testcase>
+			</testsuite>`),
 			expected: []Suite{
 				{
 					Tests: []Test{
@@ -31,6 +36,7 @@ func TestIngest(t *testing.T) {
 								"name": "unit tests",
 							},
 							SystemOut: "Hello, World",
+							SystemErr: "I'm an error!",
 						},
 					},
 					Totals: Totals{

--- a/types.go
+++ b/types.go
@@ -129,6 +129,14 @@ type Test struct {
 	// Additional properties from XML node attributes.
 	// Some tools use them to store additional information about test location.
 	Properties map[string]string `json:"properties" yaml:"properties"`
+
+	// SystemOut is textual test output for the suite. Usually output that is
+	// written to stdout.
+	SystemOut string `json:"stdout,omitempty" yaml:"stdout,omitempty"`
+
+	// SystemErr is textual test error output for the suite. Usually output that is
+	// written to stderr.
+	SystemErr string `json:"stderr,omitempty" yaml:"stderr,omitempty"`
 }
 
 // Error represents an erroneous test result.

--- a/types.go
+++ b/types.go
@@ -130,11 +130,11 @@ type Test struct {
 	// Some tools use them to store additional information about test location.
 	Properties map[string]string `json:"properties" yaml:"properties"`
 
-	// SystemOut is textual test output for the suite. Usually output that is
+	// SystemOut is textual output for the test case. Usually output that is
 	// written to stdout.
 	SystemOut string `json:"stdout,omitempty" yaml:"stdout,omitempty"`
 
-	// SystemErr is textual test error output for the suite. Usually output that is
+	// SystemErr is textual error output for the test case. Usually output that is
 	// written to stderr.
 	SystemErr string `json:"stderr,omitempty" yaml:"stderr,omitempty"`
 }


### PR DESCRIPTION
If tests fail, there's frequently additional info the `system-out` and `system-err` tags for each test case (at least with surefire test reports). The existing code captures suite-wide stdout/stderr, but misses the per-test-case variant.

This just duplicates the logic in order to capture per-test output as well.