### PR TITLE
Parse time durations containing commas

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -104,8 +104,11 @@ func ingestError(root xmlNode) Error {
 }
 
 func duration(t string) time.Duration {
+	// Remove commas for larger durations
+	t = strings.ReplaceAll(t, ",", "")
+
 	// Check if there was a valid decimal value
-	if s, err := strconv.ParseFloat(strings.ReplaceAll(t, ",", ""), 64); err == nil {
+	if s, err := strconv.ParseFloat(t, 64); err == nil {
 		return time.Duration(s*1000000) * time.Microsecond
 	}
 

--- a/ingest.go
+++ b/ingest.go
@@ -6,6 +6,7 @@ package junit
 
 import (
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -104,7 +105,7 @@ func ingestError(root xmlNode) Error {
 
 func duration(t string) time.Duration {
 	// Check if there was a valid decimal value
-	if s, err := strconv.ParseFloat(t, 64); err == nil {
+	if s, err := strconv.ParseFloat(strings.ReplaceAll(t, ",", ""), 64); err == nil {
 		return time.Duration(s*1000000) * time.Microsecond
 	}
 

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -113,7 +113,7 @@ func TestExamplesInTheWild(t *testing.T) {
 				var testcase = Test{
 					Name:      "testStdoutStderr",
 					Classname: "com.example.FooTest",
-					Duration:  9 * time.Millisecond,
+					Duration:  1234560 * time.Millisecond,
 					Status:    StatusFailed,
 					Error: Error{
 						Type: "java.lang.AssertionError",
@@ -122,7 +122,7 @@ func TestExamplesInTheWild(t *testing.T) {
 					Properties: map[string]string{
 						"classname": "com.example.FooTest",
 						"name":      "testStdoutStderr",
-						"time":      "0.009",
+						"time":      "1,234.56",
 					},
 					SystemOut: "Hello, World\n",
 					SystemErr: "I'm an error!\n",

--- a/testdata/surefire.xml
+++ b/testdata/surefire.xml
@@ -47,7 +47,7 @@
     <property name="sun.io.unicode.encoding" value="UnicodeBig"/>
     <property name="java.class.version" value="55.0"/>
   </properties>
-  <testcase name="testStdoutStderr" classname="com.example.FooTest" time="0.009">
+  <testcase name="testStdoutStderr" classname="com.example.FooTest" time="1,234.56">
     <failure type="java.lang.AssertionError">java.lang.AssertionError
 	at com.example.FooTest.testStdoutStderr(FooTest.java:13)
 </failure>


### PR DESCRIPTION
Issue: https://github.com/joshdk/go-junit/issues/38
For tests longer than 17 minutes, the duration field goes into 4 digits. The maven surefire plugin outputs this in a comma separated format, e.g, 1,234.56. We should remove commas before trying to parse the duration field. Ref: junit-team/junit5#1381
