### PR TITLE
feat: add timestamp field for test suite

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -30,6 +30,12 @@ func ingestSuite(root xmlNode) Suite {
 		Package:    root.Attr("package"),
 		Properties: root.Attrs,
 	}
+	if root.Attr("timestamp") != "" {
+		const layout = "2006-01-02T15:04:05"
+		if timestamp, err := time.Parse(layout, root.Attr("timestamp")); err == nil {
+			suite.Timestamp = timestamp
+		}
+	}
 
 	for _, node := range root.Nodes {
 		switch node.XMLName.Local {

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -27,6 +27,9 @@ func TestExamplesInTheWild(t *testing.T) {
 				assertLen(t, suites[0].Tests, 0)
 				assertLen(t, suites[1].Tests, 3)
 				assertError(t, suites[1].Tests[0].Error, "Assertion failed")
+
+				suite := suites[1]
+				assertEqual(t, false, suite.Timestamp.IsZero())
 			},
 		},
 		{
@@ -40,6 +43,9 @@ func TestExamplesInTheWild(t *testing.T) {
 				assertEqual(t, "STDERR text", suites[0].SystemErr)
 				assertEqual(t, "STDOUT text", suites[0].Tests[0].SystemOut)
 				assertEqual(t, "STDERR text", suites[0].Tests[0].SystemErr)
+
+				suite := suites[0]
+				assertEqual(t, true, suite.Timestamp.IsZero())
 			},
 		},
 		{

--- a/types.go
+++ b/types.go
@@ -79,6 +79,9 @@ type Suite struct {
 	// Suites is an ordered collection of suites with associated tests.
 	Suites []Suite `json:"suites,omitempty" yaml:"suites,omitempty"`
 
+	// Timestamp is the time at which the suite was run, date and time in ISO8601.
+	Timestamp time.Time `json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
+
 	// SystemOut is textual test output for the suite. Usually output that is
 	// written to stdout.
 	SystemOut string `json:"stdout,omitempty" yaml:"stdout,omitempty"`


### PR DESCRIPTION
If the timestamp attribute exists in the test suite attributes, then set the value for the timestamp field in the test suite. Otherwise, keep the default value for the timestamp field.

Solve https://github.com/joshdk/go-junit/issues/50