### PR TITLE
feat: support test case property

### DIFF
--- a/ingest.go
+++ b/ingest.go
@@ -41,7 +41,9 @@ func ingestSuite(root xmlNode) Suite {
 			suite.Tests = append(suite.Tests, testcase)
 		case "properties":
 			props := ingestProperties(node)
-			suite.Properties = props
+			for k, v := range props {
+				suite.Properties[k] = v
+			}
 		case "system-out":
 			suite.SystemOut = string(node.Content)
 		case "system-err":
@@ -90,6 +92,11 @@ func ingestTestcase(root xmlNode) Test {
 			test.Status = StatusError
 			test.Message = node.Attr("message")
 			test.Error = ingestError(node)
+		case "properties":
+			props := ingestProperties(node)
+			for k, v := range props {
+				test.Properties[k] = v
+			}
 		case "system-out":
 			test.SystemOut = string(node.Content)
 		case "system-err":

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -107,6 +107,8 @@ func TestExamplesInTheWild(t *testing.T) {
 				assertLen(t, suites[0].Tests, 1)
 				assertEqual(t, "\n                I am stdout!\n            ", suites[0].Tests[0].SystemOut)
 				assertEqual(t, "\n                I am stderr!\n            ", suites[0].Tests[0].SystemErr)
+				assertEqual(t, "some.property.value", suites[0].Tests[0].Properties["some.property.name"])
+				assertEqual(t, "some.class.name", suites[0].Tests[0].Properties["classname"])
 			},
 		},
 		{

--- a/testdata/cubic.xml
+++ b/testdata/cubic.xml
@@ -66,12 +66,12 @@
 	       type=""
 	       ></failure>
 
-	  <!-- Properties (e.g., environment settings) set during test
-	   execution. The properties element can appear 0 or once. -->
-	  <properties>
-		  <!-- property can appear multiple times. The name and value attributres are required. -->
-		  <property name="" value=""/>
-	  </properties>
+      <!-- Properties (e.g., environment settings) set during test
+       execution. The properties element can appear 0 or once. -->
+      <properties>
+	    <!-- property can appear multiple times. The name and value attributres are required. -->
+        <property name="" value=""/>
+      </properties>
 
 	  <!-- Data that was written to standard out while the test was executed. optional -->
       <system-out>STDOUT text</system-out>

--- a/testdata/cubic.xml
+++ b/testdata/cubic.xml
@@ -66,7 +66,14 @@
 	       type=""
 	       ></failure>
 
-      <!-- Data that was written to standard out while the test was executed. optional -->
+	  <!-- Properties (e.g., environment settings) set during test
+	   execution. The properties element can appear 0 or once. -->
+	  <properties>
+		  <!-- property can appear multiple times. The name and value attributres are required. -->
+		  <property name="" value=""/>
+	  </properties>
+
+	  <!-- Data that was written to standard out while the test was executed. optional -->
       <system-out>STDOUT text</system-out>
 
       <!-- Data that was written to standard error while the test was executed. optional -->

--- a/testdata/python-junit-xml.xml
+++ b/testdata/python-junit-xml.xml
@@ -2,6 +2,9 @@
 <testsuites>
     <testsuite errors="0" failures="0" name="my test suite" tests="1">
         <testcase classname="some.class.name" name="Test1" time="123.345000">
+            <properties>
+                <property name="some.property.name" value="some.property.value"/>
+            </properties>
             <system-out>
                 I am stdout!
             </system-out>


### PR DESCRIPTION
According to the documentation at https://docs.pytest.org/en/latest/reference/reference.html#record-property, we can add properties to test cases to support reading related fields.